### PR TITLE
awaiting players screen is updated when 2nd player joins

### DIFF
--- a/controllers/game-routes.js
+++ b/controllers/game-routes.js
@@ -85,7 +85,7 @@ router.get('/game/:id', async (req, res) => {
 
     //console.log(usersGameStateId, '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
 
-    res.render('game', { gamestates: [GameData.player1board.dataValues, player2data], isMyTurn, usersGameStateId, gameId });
+    res.render('game', { gamestates: [GameData.player1board.dataValues, player2data], isMyTurn, usersGameStateId, gameId, userId });
 
   } catch (err) {
     console.error(err);

--- a/public/js/game.js
+++ b/public/js/game.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 //accessing gameId through <script> in game.handlebars
 let gameid = gameId;
+let userid = userId;
 
 async function switchToNewTurn(gameid) {
   await fetch(`/game/${gameid}/turnover`, {
@@ -104,6 +105,45 @@ class Game {
 }
 const endCheck = new Game;
 
+let prevPlayer2Joined;
+async function checkP2Status(gameid) {
+  try {
+    const response = await fetch(`/json/${gameid}`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (response.ok) {
+      const GameData = await response.json();
+      // console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!GameData checkP2Status', GameData);
+      // console.log('player2:', GameData.gamestates[1]);
+      // console.log('GameData.gamestates[0].player:', GameData.gamestates[0].player);
+      // console.log('userid :', userid);
+
+      if (GameData.gamestates[1] != null) {
+        console.log('player 2 has joined the game');
+
+        if (prevPlayer2Joined === false) {
+          window.location.href = `/game/${gameid}`;
+          return;
+        }
+      } else {
+        console.log('waiting for opponent to join');
+        prevPlayer2Joined = false;
+        setTimeout(() => {
+          checkP2Status(gameid);
+        }, 8000);
+      }
+    } else {
+      console.error('big error');
+    }
+  } catch (error) {
+    console.error('Error:', error);
+  }
+}
+
+checkP2Status(gameid);
+
 
 //previousTurn will show up undefined at first, but then have a value
 let previousTurn;
@@ -133,7 +173,7 @@ async function checkTurn(gameid) {
         previousTurn = false;
         setTimeout(() => {
           checkTurn(gameid);
-        }, 3000);
+        }, 8000);
       }
     } else {
       console.error('Error fetching game data');

--- a/views/game.handlebars
+++ b/views/game.handlebars
@@ -153,6 +153,7 @@
 
 <script>const gameId = "{{ gameId }}"</script>
 <script>const usersGameStateId = "{{ usersGameStateId }}"</script>
+<script>const userId = "{{ userId }}"</script>
 
 <script src="/js/utilities.js"></script>
 <script src="/js/dice.js"></script>


### PR DESCRIPTION
I didn't get these errors during testing here. But just incase..
Compare this to what we have on main if we ever run into a null issue:

game.js: 
    let allMonumentsDone = true;
    const monumentDone = [];
    for (let i = 0; i < 5; i++) {
      monumentDone[0] = parseInt(document.querySelector(`#${player[0]} .mon${i} .needed`).textContent);
      if (monumentDone[1]) {
        monumentDone[1] = parseInt(document.querySelector(`#${player[1]} .mon${i} .needed`).textContent);
      }
      if (monumentDone[0] !== 0 && monumentDone[1] !== 0) {
        allMonumentsDone = false;
        break;
      }
    }
    let developmentsDone = 0;
    for (let j = 0; j < 2; j++) {
      for (let k = 0; k < 13; k++) {
        let developmentLearned = document.querySelector(`#${player[j]} .dev${k} .learn`);
        //developmentLearned = developmentLearned.classList.contains('learned');
        if (developmentLearned && developmentLearned.classList.contains('learned')) {
          developmentsDone += 1;
        }
        if (developmentsDone === 5) {
          break;
        }

You may have already solved this. It can't hurt to have it somewhere though

//// I just realized I didn't need to carry over userId anymore, but its there and it works, so let it be?